### PR TITLE
fixed a problem with the way we serialized tokens ...

### DIFF
--- a/lib/Token.js
+++ b/lib/Token.js
@@ -28,52 +28,52 @@ Object.defineProperty(Token.prototype,'serial',
             // takes this token object and returns a string
             // no iteration through the properties of the object, because of non-conllu properties (ex: "serialize" property)
             var id_output = "_";
-            if (!(this.id === undefined) && !(this.id === "")){
+            if (!(this.id === undefined) && !/^[ \t]*$/.test(this.id)){
                 id_output = String(this.id);
             }
 
             var form_output = "_";
-            if (!(this.id === undefined) && !(this.id === "")){
+            if (!(this.id === undefined) && !/^[ \t]*$/.test(this.id)){
                 form_output = String(this.form);
             }
 
             var lemma_output = "_";
-            if (!(this.lemma === undefined) && !(this.lemma === "")){
+            if (!(this.lemma === undefined) && !/^[ \t]*$/.test(this.lemma)){
                 lemma_output = String(this.lemma);
             }
 
             var upostag_output = "_";
-            if (!(this.upostag === undefined) && !(this.upostag === "")){
+            if (!(this.upostag === undefined) && !/^[ \t]*$/.test(this.upostag)){
                 upostag_output = String(this.upostag);
             }
 
             var xpostag_output = "_";
-            if (!(this.xpostag === undefined) && !(this.xpostag === "")){
+            if (!(this.xpostag === undefined) && !/^[ \t]*$/.test(this.xpostag)){
                 xpostag_output = String(this.xpostag);
             }
 
             var feats_output = "_";
-            if (!(this.feats === undefined) && !(this.feats === "")){
+            if (!(this.feats === undefined) && !/^[ \t]*$/.test(this.feats)){
                 feats_output = String(this.feats);
             }
 
             var head_output = "_";
-            if (!(this.head === undefined) && !(this.head === "")){
+            if (!(this.head === undefined) && !/^[ \t]*$/.test(this.head)){
                 head_output = String(this.head);
             }
 
             var deprel_output = "_";
-            if (!(this.deprel === undefined) && !(this.deprel === "")){
+            if (!(this.deprel === undefined) && !/^[ \t]*$/.test(this.deprel)){
                 deprel_output = String(this.deprel);
             }
 
             var deps_output = "_";
-            if (!(this.deps === undefined) && !(this.deps === "")){
+            if (!(this.deps === undefined) && !/^[ \t]*$/.test(this.deps)){
                 deps_output = String(this.deps);
             }
 
             var misc_output = "_";
-            if (!(this.misc === undefined) && !(this.misc === "")){
+            if (!(this.misc === undefined) && !/^[ \t]*$/.test(this.misc)){
                 misc_output = String(this.misc);
             }
 
@@ -133,4 +133,3 @@ Object.defineProperty(Token.prototype,'serial',
 if (typeof exports !== 'undefined' && this.exports !== exports) {
     exports.Token = Token;
 }
-


### PR DESCRIPTION
before, we only overwrote the stored value (e.g. `token.form`) if it was `!== undefined && !== '')`

but this could present problems re the way we deserialize strings

for example, if the value of `token.form` was set to `"\t"`, then this would serialize out as `"\t"`, not `"_"`.  when we attempt to deserialize the serialized token, we will end up splitting on that char, even though it should be interpreted as content.

as a result, we get an unstable edge condition on serializing/deserializing data

i've changed the behavior to now reject the stored value (`token.<key>`) and serialize the default (`"_"`) if the stored value is only whitespace

basically, this means i've changed all the `this.<key> !== ''` to `!/^[ \t]*$/.test(this.<key>)`